### PR TITLE
feat: add test suite, project docs, and dev dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,15 @@ data/
 data/raw/
 data/processed/
 mlruns/
+
+# Python cache
+__pycache__/
+*.pyc
+
+# MLflow local DB
+mlflow.db
+
+# Pytest cache
+.pytest_cache/
+.coverage
+htmlcov/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Environment
+
+```bash
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Secrets go in `.env` (gitignored). Required keys:
+- `API_KEY` — RapidAPI key for API-Football
+- `HOST` — defaults to `api-football-v1.p.rapidapi.com`
+
+MLflow uses a local SQLite backend (`mlflow.db`) and artifact store (`mlruns/`, gitignored).
+
+## Common Commands
+
+```bash
+# Ingest recent completed fixtures (refreshes current-season CSV)
+python src/ingest.py recent --n 5
+
+# Fetch next matchweek with odds (requires API_KEY)
+python src/ingest.py upcoming
+
+# Train LPM2 + register champion if it beats current
+python src/train.py --threshold 0.5 --test-size 0.3 --seed 42
+
+# Launch MLflow UI
+mlflow ui --backend-store-uri sqlite:///mlflow.db
+```
+
+## Architecture
+
+The system ports a university R betting model into a production ML pipeline with champion/challenger deployment.
+
+**Data flow:**
+1. `src/ingest.py` — pulls completed EPL results from football-data.co.uk (no auth) and upcoming fixtures/odds from API-Football (RapidAPI). Processed season CSVs are stored in `data/legacy/data/hist-data/processed/E0-YYYY-YYYY.csv`.
+2. `src/train.py` — loads all processed CSVs, trains LPM2 (OLS on binary outcome), logs metrics + model artifact to MLflow, then calls `maybe_register_champion()` to promote the run if it beats the current champion on both accuracy and ROI.
+3. `src/features.py`, `src/evaluate.py`, `src/monitor.py`, `src/serve.py` — stubs for future implementation (see priority build order below).
+
+**Model:**
+- LPM2 (Linear Probability Model) — sklearn `LinearRegression` on two features: `B365H` (Bet365 home-win odds) and `HomePPG_Last5` (rolling 5-game home PPG).
+- Threshold converts continuous probability to binary bet signal (default 0.5; R legacy used 0.8).
+- ROI metric mirrors the R model: £100 fixed stake, bet when `y_pred == 1`.
+
+**Champion/challenger:**
+- MLflow Model Registry with alias `champion` on model name `epl-home-win-lpm2`.
+- Promotion requires the candidate to beat the current champion on **both** accuracy and ROI. First run is always promoted.
+
+**Legacy:**
+- `legacy/` contains the original R model (`Training, Testing & Betting Algorithm.r`).
+- `data/legacy/` contains historical CSVs and cleaning notebooks.
+
+## Priority Build Order
+
+1. Python port + MLflow tracking — **done** (`src/train.py`)
+2. API data ingestion — **done** (`src/ingest.py`)
+3. Model Registry + champion registration — **done** (inside `src/train.py`)
+4. Drift monitoring — `src/monitor.py` (stub)
+5. FastAPI serving endpoint — `src/serve.py` (stub)
+6. GitHub Actions CI/CD — not started

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,9 @@ tzdata==2025.2
 urllib3==2.3.0
 wcwidth==0.2.13
 xgboost==3.0.0
+mlflow==3.11.1
+fastapi==0.136.1
+uvicorn==0.46.0
+httpx==0.28.1
+pytest==8.3.5
+pytest-cov==6.1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,80 @@
+"""Shared pytest fixtures — synthetic data, no live APIs or real DB."""
+
+import pathlib
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def sample_historical_df() -> pd.DataFrame:
+    """
+    30-row synthetic EPL dataset with all columns produced by ingest.py.
+    Seed 42 for reproducibility. Covers home wins, draws, and away wins.
+    """
+    rng = np.random.default_rng(42)
+    n = 30
+    teams = ["Arsenal", "Chelsea", "Liverpool", "Man City", "Spurs", "Everton"]
+    home_teams = [teams[i % len(teams)] for i in range(n)]
+    away_teams = [teams[(i + 1) % len(teams)] for i in range(n)]
+
+    ftr_choices = rng.choice(["H", "D", "A"], size=n, p=[0.46, 0.26, 0.28])
+    home_win = (ftr_choices == "H").astype(int)
+    away_win = (ftr_choices == "A").astype(int)
+    draw = (ftr_choices == "D").astype(int)
+    home_points = home_win * 3 + draw
+
+    b365h = rng.uniform(1.5, 5.0, n).round(2)
+    b365d = rng.uniform(2.8, 4.5, n).round(2)
+    b365a = rng.uniform(1.8, 6.0, n).round(2)
+
+    dates = pd.date_range("2024-08-01", periods=n, freq="7D")
+
+    df = pd.DataFrame({
+        "Date": dates.strftime("%Y-%m-%d"),
+        "Time": ["15:00"] * n,
+        "HomeTeam": home_teams,
+        "AwayTeam": away_teams,
+        "FTR": ftr_choices,
+        "B365H": b365h,
+        "B365D": b365d,
+        "B365A": b365a,
+        "HomeWin": home_win,
+        "AwayWin": away_win,
+        "Draw": draw,
+        "HomePoints": home_points,
+        "HomePPG_Last5": rng.uniform(0.5, 2.5, n).round(2),
+    })
+    return df
+
+
+@pytest.fixture
+def sample_upcoming_df() -> pd.DataFrame:
+    """
+    5-row synthetic upcoming fixtures — no FTR/HomeWin/AwayWin/Draw columns.
+    """
+    return pd.DataFrame({
+        "Date": ["2025-05-17"] * 5,
+        "HomeTeam": ["Arsenal", "Chelsea", "Liverpool", "Man City", "Spurs"],
+        "AwayTeam": ["Everton", "Arsenal", "Chelsea", "Liverpool", "Man City"],
+        "B365H": [2.1, 1.8, 2.4, 1.5, 3.0],
+        "B365D": [3.4, 3.8, 3.3, 4.2, 3.1],
+        "B365A": [3.8, 4.5, 3.0, 6.5, 2.4],
+        "HomePPG_Last5": [2.4, 1.8, 2.1, 2.8, 1.5],
+    })
+
+
+@pytest.fixture
+def sample_predictions_df(sample_upcoming_df) -> pd.DataFrame:
+    """upcoming_df enriched with prob_home_win and bet_placed columns."""
+    df = sample_upcoming_df.copy()
+    df["prob_home_win"] = [0.72, 0.61, 0.45, 0.83, 0.38]
+    df["bet_placed"] = [1, 1, 0, 1, 0]
+    return df
+
+
+@pytest.fixture
+def tmp_db(tmp_path) -> pathlib.Path:
+    """Path to a temporary SQLite DB (auto-cleaned by pytest)."""
+    return tmp_path / "test_predictions.db"

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,0 +1,115 @@
+"""Unit tests for src/features.py — pure computation, no I/O."""
+
+import sys
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from features import (
+    FEATURE_SETS,
+    add_away_ppg,
+    add_implied_probs,
+    build_feature_set,
+    build_predict_features,
+    enrich,
+)
+
+
+def test_add_away_ppg_non_negative(sample_historical_df):
+    result = add_away_ppg(sample_historical_df)
+    assert "AwayPPG_Last5" in result.columns
+    assert (result["AwayPPG_Last5"] >= 0).all()
+
+
+def test_add_away_ppg_max_three(sample_historical_df):
+    result = add_away_ppg(sample_historical_df)
+    assert (result["AwayPPG_Last5"] <= 3.0).all()
+
+
+def test_add_away_ppg_missing_columns_returns_nan():
+    """DataFrames without AwayWin/Draw (upcoming fixtures) get NaN column."""
+    df = pd.DataFrame({"AwayTeam": ["Arsenal"], "Date": ["2025-01-01"]})
+    result = add_away_ppg(df)
+    assert "AwayPPG_Last5" in result.columns
+    assert result["AwayPPG_Last5"].isna().all()
+
+
+def test_add_implied_probs_reciprocal(sample_historical_df):
+    result = add_implied_probs(sample_historical_df)
+    np.testing.assert_allclose(
+        result["ImpliedH"].values,
+        (1.0 / result["B365H"]).values,
+        rtol=1e-6,
+    )
+
+
+def test_implied_odds_sum_exceeds_one():
+    """Real bookmaker odds always have over-round (sum of implied probs > 1)."""
+    df = pd.DataFrame({
+        "B365H": [2.0, 1.8, 3.5],
+        "B365D": [3.5, 3.8, 3.2],
+        "B365A": [4.0, 5.0, 2.1],
+    })
+    result = add_implied_probs(df)
+    total = result["ImpliedH"] + result["ImpliedD"] + result["ImpliedA"]
+    assert (total > 1.0).all(), "Bookmaker over-round means sum of implied probs > 1"
+
+
+def test_add_implied_probs_missing_column_raises():
+    df = pd.DataFrame({"B365H": [2.0], "B365D": [3.0]})
+    with pytest.raises(ValueError, match="B365A"):
+        add_implied_probs(df)
+
+
+def test_build_feature_set_lpm2_shape(sample_historical_df):
+    X, y, odds = build_feature_set(sample_historical_df, "lpm2")
+    assert X.shape[1] == len(FEATURE_SETS["lpm2"])
+    assert len(X) == len(y) == len(odds)
+
+
+def test_build_feature_set_lpm1_shape(sample_historical_df):
+    X, y, odds = build_feature_set(sample_historical_df, "lpm1")
+    assert X.shape[1] == len(FEATURE_SETS["lpm1"])
+
+
+def test_build_feature_set_xgb_shape(sample_historical_df):
+    X, y, odds = build_feature_set(sample_historical_df, "xgb")
+    assert X.shape[1] == len(FEATURE_SETS["xgb"])
+
+
+def test_build_feature_set_unknown_type_raises(sample_historical_df):
+    with pytest.raises(ValueError, match="Unknown model_type"):
+        build_feature_set(sample_historical_df, "rfc")
+
+
+def test_build_feature_set_drops_nan_rows(sample_historical_df):
+    df = sample_historical_df.copy()
+    df.loc[0, "B365H"] = float("nan")
+    X_full, _, _ = build_feature_set(sample_historical_df, "lpm2")
+    X_with_nan, _, _ = build_feature_set(df, "lpm2")
+    assert len(X_with_nan) == len(X_full) - 1
+
+
+def test_build_predict_features_no_nan(sample_upcoming_df):
+    X = build_predict_features(sample_upcoming_df, "lpm2")
+    assert not X.isna().any().any()
+
+
+def test_build_predict_features_lpm1_fills_away_ppg(sample_upcoming_df):
+    """lpm1 requires AwayPPG_Last5 which is missing from upcoming df — should fill."""
+    X = build_predict_features(sample_upcoming_df, "lpm1")
+    assert not X.isna().any().any()
+    assert "AwayPPG_Last5" in X.columns
+
+
+def test_all_model_types_defined():
+    expected = {"lpm1", "lpm2", "glm1", "glm2", "xgb"}
+    assert set(FEATURE_SETS.keys()) == expected
+
+
+def test_build_predict_features_unknown_type_raises(sample_upcoming_df):
+    with pytest.raises(ValueError, match="Unknown model_type"):
+        build_predict_features(sample_upcoming_df, "neural_net")

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,133 @@
+"""Unit tests for src/monitor.py — uses tmp_db fixture, never touches real DB."""
+
+import pathlib
+import sqlite3
+import sys
+import os
+
+import pandas as pd
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+import monitor
+
+
+def test_init_db_creates_tables(tmp_db):
+    monitor.init_db(tmp_db)
+    with sqlite3.connect(str(tmp_db)) as conn:
+        tables = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+    assert "predictions" in tables
+    assert "results" in tables
+
+
+def test_init_db_idempotent(tmp_db):
+    monitor.init_db(tmp_db)
+    monitor.init_db(tmp_db)  # second call must not raise
+
+
+def test_record_predictions_inserts_rows(sample_predictions_df, tmp_db):
+    n = monitor.record_predictions(
+        sample_predictions_df,
+        model_name="epl-home-win",
+        model_version="1",
+        db_path=tmp_db,
+    )
+    assert n == len(sample_predictions_df)
+
+
+def test_record_predictions_idempotent(sample_predictions_df, tmp_db):
+    monitor.record_predictions(
+        sample_predictions_df,
+        model_name="epl-home-win",
+        model_version="1",
+        db_path=tmp_db,
+    )
+    n2 = monitor.record_predictions(
+        sample_predictions_df,
+        model_name="epl-home-win",
+        model_version="1",
+        db_path=tmp_db,
+    )
+    assert n2 == 0  # all rows already exist
+
+
+def test_record_actuals_inserts_results(sample_historical_df, tmp_db, tmp_path):
+    csv_path = tmp_path / "E0-2024-2025.csv"
+    sample_historical_df.to_csv(csv_path, index=False)
+    n = monitor.record_actuals(data_dir=tmp_path, db_path=tmp_db)
+    expected = int(sample_historical_df["FTR"].notna().sum())
+    assert n == expected
+
+
+def test_record_actuals_idempotent(sample_historical_df, tmp_db, tmp_path):
+    csv_path = tmp_path / "E0-2024-2025.csv"
+    sample_historical_df.to_csv(csv_path, index=False)
+    monitor.record_actuals(data_dir=tmp_path, db_path=tmp_db)
+    n2 = monitor.record_actuals(data_dir=tmp_path, db_path=tmp_db)
+    assert n2 == 0
+
+
+def _seed_one_bet(tmp_db, b365h: float, bet_result: int, actual_home_win: int) -> None:
+    """Helper: insert one prediction and one matching result."""
+    monitor.init_db(tmp_db)
+    with sqlite3.connect(str(tmp_db)) as conn:
+        conn.execute(
+            """INSERT OR IGNORE INTO predictions
+               (prediction_date, match_date, home_team, away_team,
+                model_name, model_version, model_alias,
+                b365h, b365d, b365a, home_ppg,
+                prob_home_win, threshold, bet_placed)
+               VALUES ('2025-01-01','2025-01-15','Arsenal','Chelsea',
+                       'epl-home-win','1','champion',
+                       ?,3.0,3.5,2.0,0.7,0.5,1)""",
+            (b365h,),
+        )
+        conn.execute(
+            """INSERT OR IGNORE INTO results
+               (match_date, home_team, away_team, ftr, actual_home_win, recorded_at)
+               VALUES ('2025-01-15','Arsenal','Chelsea','H',?,
+                       '2025-01-15T21:00:00')""",
+            (actual_home_win,),
+        )
+        conn.commit()
+
+
+def test_compute_live_roi_correct_bet(tmp_db):
+    """Single correct bet at odds 2.0 → ROI = 100%."""
+    _seed_one_bet(tmp_db, b365h=2.0, bet_result=1, actual_home_win=1)
+    stats = monitor.compute_live_roi(db_path=tmp_db)
+    assert stats["n_bets"] == 1
+    assert stats["n_wins"] == 1
+    assert abs(stats["roi_pct"] - 100.0) < 0.01
+
+
+def test_compute_live_roi_wrong_bet(tmp_db):
+    """Single wrong bet → ROI = -100%."""
+    _seed_one_bet(tmp_db, b365h=2.0, bet_result=1, actual_home_win=0)
+    stats = monitor.compute_live_roi(db_path=tmp_db)
+    assert stats["n_wins"] == 0
+    assert abs(stats["roi_pct"] - (-100.0)) < 0.01
+
+
+def test_compute_live_roi_no_bets(tmp_db):
+    monitor.init_db(tmp_db)
+    stats = monitor.compute_live_roi(db_path=tmp_db)
+    assert stats["n_bets"] == 0
+    assert stats["roi_pct"] == 0.0
+
+
+def test_pending_predictions_returns_unresolved(sample_predictions_df, tmp_db):
+    monitor.record_predictions(
+        sample_predictions_df,
+        model_name="epl-home-win",
+        model_version="1",
+        db_path=tmp_db,
+    )
+    pending = monitor.pending_predictions(db_path=tmp_db)
+    n_bets = int((sample_predictions_df["bet_placed"] == 1).sum())
+    assert len(pending) == n_bets

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1,0 +1,94 @@
+"""Integration tests for src/serve.py FastAPI app — no live MLflow calls."""
+
+import sys
+import os
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from fastapi.testclient import TestClient
+from serve import app, score_fixtures
+
+client = TestClient(app)
+
+FIXTURE_PAYLOAD = {
+    "home_team": "Arsenal",
+    "away_team": "Chelsea",
+    "b365h": 2.1,
+    "b365d": 3.4,
+    "b365a": 3.8,
+    "home_ppg_last5": 2.4,
+}
+
+
+def _mock_champion(prob: float = 0.72):
+    """Return a mock (model, version, name) tuple whose model predicts *prob*."""
+    model = MagicMock()
+    model.predict.return_value = np.array([prob])
+    return model, "1", "epl-home-win"
+
+
+def test_health_returns_200():
+    with patch("serve.load_champion", return_value=_mock_champion()):
+        resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+def test_health_no_champion_returns_ok_with_no_champion():
+    from fastapi import HTTPException
+    with patch("serve.load_champion", side_effect=HTTPException(status_code=503, detail="no model")):
+        resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "no_champion"
+
+
+def test_predict_returns_200(sample_upcoming_df):
+    with (
+        patch("serve.load_champion", return_value=_mock_champion(0.72)),
+        patch("serve._get_model_type", return_value="lpm2"),
+    ):
+        resp = client.post("/predict", json=FIXTURE_PAYLOAD)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "prob_home_win" in body
+    assert "bet_placed" in body
+    assert body["model_version"] == "1"
+
+
+def test_predict_bet_placed_when_above_threshold():
+    with (
+        patch("serve.load_champion", return_value=_mock_champion(0.9)),
+        patch("serve._get_model_type", return_value="lpm2"),
+    ):
+        resp = client.post("/predict", json=FIXTURE_PAYLOAD)
+    assert resp.json()["bet_placed"] is True
+
+
+def test_predict_no_bet_when_below_threshold():
+    with (
+        patch("serve.load_champion", return_value=_mock_champion(0.1)),
+        patch("serve._get_model_type", return_value="lpm2"),
+    ):
+        resp = client.post("/predict?threshold=0.5", json=FIXTURE_PAYLOAD)
+    assert resp.json()["bet_placed"] is False
+
+
+def test_score_fixtures_clips_lpm_overflow(sample_upcoming_df):
+    """LPM can predict > 1.0; score_fixtures must clip to [0, 1]."""
+    model = MagicMock()
+    model.predict.return_value = np.array([1.5, 0.8, -0.1, 0.6, 0.4])
+    result = score_fixtures(sample_upcoming_df, model, model_type="lpm2", threshold=0.5)
+    assert (result["prob_home_win"] <= 1.0).all()
+    assert (result["prob_home_win"] >= 0.0).all()
+
+
+def test_score_fixtures_bet_placed_column(sample_upcoming_df):
+    model = MagicMock()
+    model.predict.return_value = np.array([0.7, 0.3, 0.8, 0.2, 0.6])
+    result = score_fixtures(sample_upcoming_df, model, model_type="lpm2", threshold=0.5)
+    expected_bets = [1, 0, 1, 0, 1]
+    assert list(result["bet_placed"]) == expected_bets

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,87 @@
+"""Unit tests for src/train.py — pure computation, no MLflow calls."""
+
+import sys
+import os
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+from train import classify, compute_roi, _instantiate_model, build_features
+
+
+def test_classify_at_threshold_is_positive():
+    probs = np.array([0.5, 0.499, 0.501])
+    result = classify(probs, 0.5)
+    assert list(result) == [1, 0, 1]
+
+
+def test_classify_all_below_threshold():
+    probs = np.array([0.1, 0.2, 0.3])
+    assert list(classify(probs, 0.5)) == [0, 0, 0]
+
+
+def test_classify_all_above_threshold():
+    probs = np.array([0.6, 0.7, 0.9])
+    assert list(classify(probs, 0.5)) == [1, 1, 1]
+
+
+def test_compute_roi_all_correct_at_2():
+    y_true = np.array([1, 1])
+    y_pred = np.array([1, 1])
+    odds = np.array([2.0, 2.0])
+    assert abs(compute_roi(y_true, y_pred, odds) - 100.0) < 1e-6
+
+
+def test_compute_roi_all_wrong():
+    y_true = np.array([0, 0])
+    y_pred = np.array([1, 1])
+    odds = np.array([2.0, 2.0])
+    assert abs(compute_roi(y_true, y_pred, odds) - (-100.0)) < 1e-6
+
+
+def test_compute_roi_no_bets():
+    y_true = np.array([1, 0])
+    y_pred = np.array([0, 0])
+    odds = np.array([2.0, 3.0])
+    assert compute_roi(y_true, y_pred, odds) == 0.0
+
+
+def test_compute_roi_mixed():
+    """2 bets: one win (odds 3.0), one loss. Net = +200 -100 = +100. ROI = 50%."""
+    y_true = np.array([1, 0])
+    y_pred = np.array([1, 1])
+    odds = np.array([3.0, 2.0])
+    assert abs(compute_roi(y_true, y_pred, odds) - 50.0) < 1e-6
+
+
+def test_instantiate_model_lpm2():
+    from sklearn.linear_model import LinearRegression
+    m = _instantiate_model("lpm2")
+    assert isinstance(m, LinearRegression)
+
+
+def test_instantiate_model_glm1():
+    from sklearn.linear_model import LogisticRegression
+    m = _instantiate_model("glm1")
+    assert isinstance(m, LogisticRegression)
+
+
+def test_instantiate_model_xgb():
+    import xgboost as xgb
+    m = _instantiate_model("xgb")
+    assert isinstance(m, xgb.XGBClassifier)
+
+
+def test_instantiate_model_unknown_raises():
+    with pytest.raises(ValueError, match="Unknown model_type"):
+        _instantiate_model("rfc")
+
+
+def test_build_features_drops_nan_rows(sample_historical_df):
+    import pandas as pd
+    df = sample_historical_df.copy()
+    df.loc[0, "B365H"] = float("nan")
+    X_full, _, _ = build_features(sample_historical_df)
+    X_nan, _, _ = build_features(df)
+    assert len(X_nan) == len(X_full) - 1


### PR DESCRIPTION
## Summary

- 44 unit/integration tests across `test_features.py`, `test_monitor.py`, `test_train.py`, `test_serve.py`
- FastAPI tests use `TestClient` with `unittest.mock.patch` on `load_champion` — no live MLflow calls
- Monitor tests use `tmp_db` fixture (pytest `tmp_path`) — no shared state between tests
- Adds `CLAUDE.md` with architecture overview and common commands for future Claude Code sessions
- Adds `fastapi`, `uvicorn`, `httpx`, `pytest`, `pytest-cov` to `requirements.txt`
- Updates `.gitignore` for `__pycache__`, `mlflow.db`, pytest artifacts

## Test coverage

```
pytest tests/ -v --cov=src
44 passed in 4.56s
```

## Test plan

- [ ] `pip install -r requirements.txt && pytest tests/ -v` — all 44 pass
- [ ] `pytest tests/ --cov=src --cov-report=term-missing` shows coverage

🤖 Generated with [Claude Code](https://claude.ai/claude-code)