### PR TITLE
docs: reframe Claude-facing docs around product aims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,39 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Product
+
+An EPL match-prediction service that produces probability-calibrated pre-match bets and reconciles them against actual results for a live ROI figure.
+
+- **Who it's for:** a small private user group (you + a few people). Opening it up further is a future option, not a current optimisation target.
+- **How it operates:** on a schedule — refresh data, retrain when warranted, score the upcoming matchweek, monitor drift, surface results.
+
+## Goals
+
+In priority order:
+
+1. **Correct, calibrated home-win predictions for EPL** — reproducible training, walk-forward backtests, live ROI reconciliation.
+2. **Operational reliability** — drift monitoring (Evidently AI), scheduled retraining, scheduled scoring. The system should run without manual intervention week-to-week.
+3. **Extensible architecture** — adding a league or a bet-type should not require a rewrite. Feature engineering, registry naming, and storage layout are designed for this.
+4. **Shareable when ready** — opening up to a few more users should be a small step (auth + lightweight UI), not a rebuild.
+
+## Non-goals
+
+Explicitly out of scope right now:
+
+- Public SaaS, paying users, billing, multi-tenant.
+- Live/in-play scoring.
+- Bankroll management, Kelly sizing, automated bet execution.
+- Bet types beyond home-win (roadmap).
+- Leagues beyond EPL (roadmap).
+
+## Roadmap
+
+- **Phase 1 — Operational hardening (now):** Evidently drift monitoring on features + predictions; scheduled retraining (cron / GH Actions / cloud scheduler — TBD); scheduled weekly matchweek scoring; GitHub Actions CI for tests + lint.
+- **Phase 2 — Model scope:** additional EPL bet types (draw, away-win, over/under 2.5, BTTS); calibration check + isotonic/Platt calibration if needed.
+- **Phase 3 — League scope:** generalise ingest + features + registry to a second league (likely La Liga or Bundesliga).
+- **Phase 4 — Sharing:** lightweight auth, multi-user prediction view, hosted somewhere always-on.
+
 ## Environment
 
 ```bash
@@ -52,7 +85,7 @@ mlflow ui --backend-store-uri sqlite:///mlflow.db
 
 ## Architecture
 
-The system ports a university R betting model into a production ML pipeline with champion/challenger deployment.
+A scheduled ML pipeline with champion/challenger deployment via the MLflow Model Registry.
 
 **Data flow:**
 1. `src/ingest.py` — pulls completed EPL results from football-data.co.uk (no auth) and upcoming fixtures/odds from API-Football (RapidAPI). Processed season CSVs are stored in `data/legacy/data/hist-data/processed/E0-YYYY-YYYY.csv`.
@@ -64,7 +97,13 @@ The system ports a university R betting model into a production ML pipeline with
 
 **Models:** LPM1, LPM2 (OLS), GLM1, GLM2 (logistic), XGBoost — all compete in the `epl-home-win` registry. Current champion: XGBoost.
 
-**Legacy:** `legacy/` contains the original R model. `data/legacy/` contains historical CSVs and cleaning notebooks.
+**Legacy:** `legacy/` contains the original R model the Python pipeline was ported from. `data/legacy/` contains historical CSVs and cleaning notebooks.
+
+**Designed to extend:** the seams where Phase 2/3 scope will plug in.
+
+- **Registry naming.** Today: `epl-home-win` (multi-model, `MULTI_REGISTERED_MODEL_NAME` in `src/train.py:53`) and a backward-compat `epl-home-win-lpm2` (`REGISTERED_MODEL_NAME` in `src/train.py:51`). Serving falls back from one to the other (`DEFAULT_MODEL_NAME` / `FALLBACK_MODEL_NAME` in `src/serve.py:46-47`). Future shape: `{league}-{market}` (e.g. `epl-draw`, `laliga-home-win`). Those four constants are the points that bake `epl-home-win` in — change them together.
+- **Feature module.** `src/features.py` centralises `FEATURE_SETS` keyed by model type. New markets should add new keys (e.g. `xgb_draw`) alongside the existing `lpm1/lpm2/glm1/glm2/xgb`, not replace them. Keep features league-agnostic where possible — PPG-style features generalise; bookmaker-specific columns like `B365H` may not.
+- **Ingest.** `src/ingest.py` hardcodes EPL endpoints. A future refactor will need a `league` parameter; not blocking now.
 
 ## Git Workflow
 
@@ -77,6 +116,7 @@ The system ports a university R betting model into a production ML pipeline with
 | `feat/` | New functionality | `feat/drift-monitoring` |
 | `bug/` | Fix a defect | `bug/ppg-rolling-window` |
 | `dev/` | Exploratory or WIP work | `dev/xgb-hyperparameter-search` |
+| `docs/` | Docs-only change | `docs/reframe-product-aims` |
 
 ### Workflow
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,26 +1,29 @@
 # EPL Predictor — Project Context
 
-## What this is
-A university EPL betting model being engineered into a production ML system.
-Goal: demonstrate production ML engineering for a job interview at LEGO.
+## Product
 
-## Architecture decisions
-- Models: LPM1, LPM2, GLM1, GLM2 (porting from R to Python)
-- Tracking: MLflow experiment tracking + Model Registry
-- Champion/challenger: best model on accuracy + ROI promoted to champion
-- Data: football-data.org API replacing static Excel file
-- Monitoring: Evidently AI for drift detection
-- Serving: FastAPI endpoint wrapping MLflow model
-- CI/CD: GitHub Actions with quality gates
+An EPL match-prediction service. It produces probability-calibrated pre-match bets, reconciles them against actual results for a live ROI figure, and runs on a schedule (refresh data → retrain when warranted → score next matchweek → monitor drift). Intended for a small private user group; openable later, but not optimised for that today.
 
-## Current state
-- Original models written in R (see legacy/models.R)
-- Porting to Python with MLflow tracking as first step
+## Goals
 
-## Priority build order
-1. Python port + MLflow tracking
-2. API data ingestion
-3. Model Registry + champion registration
-4. Drift monitoring
-5. FastAPI serving endpoint
-6. GitHub Actions CI/CD
+1. Correct, calibrated home-win predictions for EPL with reproducible training, walk-forward backtests, and live ROI reconciliation.
+2. Operational reliability — drift monitoring, scheduled retraining, scheduled scoring.
+3. Extensible architecture — a new league or bet-type plugs in, doesn't require a rewrite.
+4. Shareable when ready — a small auth + UI step away from opening up to more users.
+
+## Non-goals
+
+- Public SaaS, billing, multi-tenant.
+- Live/in-play scoring.
+- Bankroll management, Kelly sizing, automated bet execution.
+- Bet types beyond home-win (roadmap).
+- Leagues beyond EPL (roadmap).
+
+## Roadmap
+
+- **Phase 1 — Operational hardening (now):** Evidently drift monitoring; scheduled retraining + scoring; GitHub Actions CI.
+- **Phase 2 — Model scope:** additional EPL bet types (draw, away-win, O/U 2.5, BTTS); calibration check.
+- **Phase 3 — League scope:** generalise ingest + features + registry to a second league.
+- **Phase 4 — Sharing:** lightweight auth, multi-user view, always-on hosting.
+
+See `CLAUDE.md` for architecture, commands, and the extensibility seams.


### PR DESCRIPTION
## Summary
- `CLAUDE.md` and `CONTEXT.md` led future Claude Code sessions into the original "port the R model for a portfolio/interview" framing. The product has moved on — a small private EPL-prediction service with a path to more bet types and leagues — so the docs should optimise sessions for **correct, calibrated, extensible, operable** rather than demo polish.
- Adds explicit **Product / Goals / Non-goals / Roadmap** sections so scope and priorities are unambiguous.
- Adds a **Designed to extend** subsection naming the registry, feature-set, and ingest seams — including `file:line` refs to the constants that currently bake `epl-home-win` in (`MULTI_REGISTERED_MODEL_NAME` in `src/train.py:53`, `REGISTERED_MODEL_NAME` in `src/train.py:51`, `DEFAULT_MODEL_NAME` / `FALLBACK_MODEL_NAME` in `src/serve.py:46-47`).
- Rewrites `CONTEXT.md` to mirror the same structure, shorter, pointing back to `CLAUDE.md` for architecture detail.
- Adds `docs/` to the branch-naming table.

## Follow-up
- `README.md` carries the same stale framing in its lead paragraph and status checklist — to be reframed in a separate PR (user-facing, broader changes).

## Test plan
- [ ] Read `CLAUDE.md` end-to-end — a fresh Claude session opening it should understand it's a real product, what's in scope vs. out, what comes next, and where the extensibility seams live.
- [ ] Read `CONTEXT.md` end-to-end — same check, abbreviated.
- [ ] `grep -rniE "interview|portfolio|LEGO|university" .` shows only the expected remaining hit (`README.md` lead — deferred).
- [ ] Spot-check `## Common Commands` still matches reality: `python src/train.py --help` and `python src/serve.py --help` (no functional changes in this PR — sanity check only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)