### PR TITLE
docs: rescope as a betting-strategy research platform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,36 +4,59 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Product
 
-An EPL match-prediction service that produces probability-calibrated pre-match bets and reconciles them against actual results for a live ROI figure.
+A **betting-strategy research platform**. A pipeline for ingesting match data + odds, defining strategies, backtesting them honestly, tracking live performance, and comparing them — so theories from reading and experimentation can be tried out cheaply without rebuilding the system each time.
 
-- **Who it's for:** a small private user group (you + a few people). Opening it up further is a future option, not a current optimisation target.
-- **How it operates:** on a schedule — refresh data, retrain when warranted, score the upcoming matchweek, monitor drift, surface results.
+- **Who it's for:** the user (researcher), plugging in strategies as they read. Optional small group later.
+- **What it produces:** for each registered strategy — a leakage-safe walk-forward backtest, a calibration view, this week's recommended bets with Kelly-sized stakes, and a live P&L track-record reconciled against actual results.
+- **How it operates:** locally, single-process, on a schedule once Phase 4 lands. Streamlit UI on top of a SQLite store.
+
+## Core abstraction
+
+> **Strategy = feature set + model + sizing rule + target market.**
+
+The existing XGB home-win setup is `strategy_v1`. A future "Elo + rest days → Poisson goals → fractional Kelly → over 2.5" is just another strategy. Same ingest, same backtest harness, same UI compares them. The platform is the product; strategies are the content.
 
 ## Goals
 
 In priority order:
 
-1. **Correct, calibrated home-win predictions for EPL** — reproducible training, walk-forward backtests, live ROI reconciliation.
-2. **Operational reliability** — drift monitoring (Evidently AI), scheduled retraining, scheduled scoring. The system should run without manual intervention week-to-week.
-3. **Extensible architecture** — adding a league or a bet-type should not require a rewrite. Feature engineering, registry naming, and storage layout are designed for this.
-4. **Shareable when ready** — opening up to a few more users should be a small step (auth + lightweight UI), not a rebuild.
+1. **A pipeline that makes testing a new strategy cheap** — define a feature set + model + sizing + market in a config, run a backtest, get an honest answer.
+2. **Honest backtests.** Walk-forward, leakage-guarded, transaction-cost-aware, bankroll-aware. The platform's credibility depends on this.
+3. **Strategy comparability.** Every strategy uses the same data, the same harness, the same metrics. Apples-to-apples by construction.
+4. **Extensibility.** New leagues, new bookmakers, new markets, new features plug in as config + small modules — never as forks.
+5. **Shareable when ready.** Local-only today; a future step to multi-user is a small one (auth + hosted DB), not a rewrite.
 
 ## Non-goals
 
 Explicitly out of scope right now:
 
-- Public SaaS, paying users, billing, multi-tenant.
-- Live/in-play scoring.
-- Bankroll management, Kelly sizing, automated bet execution.
-- Bet types beyond home-win (roadmap).
-- Leagues beyond EPL (roadmap).
+- Real-money execution / placing bets via a broker API.
+- Public SaaS, billing, multi-tenant, hosted always-on.
+- Live / in-play scoring.
+- Building a strategy that "wins" before the platform is honest. The first job is to know how good a strategy actually is, not to make it look good.
+- Polish on the legacy `src/` modules. They are scheduled for deletion (see Roadmap Phase 2).
 
 ## Roadmap
 
-- **Phase 1 — Operational hardening (now):** Evidently drift monitoring on features + predictions; scheduled retraining (cron / GH Actions / cloud scheduler — TBD); scheduled weekly matchweek scoring; GitHub Actions CI for tests + lint.
-- **Phase 2 — Model scope:** additional EPL bet types (draw, away-win, over/under 2.5, BTTS); calibration check + isotonic/Platt calibration if needed.
-- **Phase 3 — League scope:** generalise ingest + features + registry to a second league (likely La Liga or Bundesliga).
-- **Phase 4 — Sharing:** lightweight auth, multi-user prediction view, hosted somewhere always-on.
+The previous home-win-focused roadmap is superseded. New phases:
+
+- **Phase 1 — Platform foundations (now):**
+  - SQLite schema (`matches`, `odds_snapshots`, `features`, `strategies`, `backtest_runs`, `live_predictions`, `settled_bets`) + migrations.
+  - `platform/ingest/` — `ingest_matches` (football-data.co.uk) and `ingest_odds` (API-Football), idempotent, parameterised by `(league, season, book, market)`.
+  - `platform/features/` — feature modules (PPG, implied prob, odds ratio to start; Elo / xG / rest later).
+  - `platform/backtest/` — walk-forward harness with leakage guard, transaction costs, Kelly-aware sizing interface.
+- **Phase 2 — Strategy abstraction + `strategy_v1`:**
+  - Define `Strategy` as a versioned config object (feature set + model URI + sizing rule + market).
+  - Port the existing XGB home-win as `strategy_v1`. End-to-end backtest under honest conditions.
+  - Delete `src/train.py`, `src/serve.py`, `src/monitor.py`, `src/evaluate.py`, and the LPM1/LPM2/GLM1/GLM2 model families.
+- **Phase 3 — Streamlit research UI:**
+  - Strategy gallery, strategy detail (equity curve + calibration + recent picks), this-week scoreboard, add-strategy flow.
+- **Phase 4 — Ops:**
+  - Scheduled ingest + scheduled scoring; drift detection per strategy; GitHub Actions CI for tests + lint.
+- **Phase 5 — Strategy expansion:**
+  - Each new theory = one feature module + one strategy config. Platform itself doesn't change.
+- **Phase 6 — Multi-league:**
+  - Add a second league via config + ingest parameters, not code.
 
 ## Environment
 
@@ -46,9 +69,11 @@ Secrets go in `.env` (gitignored). Required keys:
 - `API_KEY` — RapidAPI key for API-Football
 - `HOST` — defaults to `api-football-v1.p.rapidapi.com`
 
-MLflow uses a local SQLite backend (`mlflow.db`) and artifact store (`mlruns/`, gitignored).
+MLflow uses a local SQLite backend (`mlflow.db`) and artifact store (`mlruns/`, gitignored). The platform's own data lives in a separate SQLite DB (`platform.db`, also gitignored, created by Phase 1).
 
 ## Common Commands
+
+> **Note:** the commands below operate on the legacy `src/` pipeline. They still work today and will be deleted in Phase 2. New `platform/` commands will be documented here as each phase lands.
 
 ```bash
 # Ingest recent completed fixtures (refreshes current-season CSV)
@@ -57,24 +82,18 @@ python src/ingest.py recent --n 5
 # Fetch next matchweek with odds (requires API_KEY)
 python src/ingest.py upcoming
 
-# Train a single model type
+# Train a single model type (legacy)
 python src/train.py --model-type xgb --threshold 0.5
 
-# Train all 5 model types (promotes champion automatically)
-python src/train.py --all
-
-# Walk-forward backtest
+# Walk-forward backtest (legacy)
 python src/evaluate.py compare
 
-# Score upcoming matchweek + save predictions to DB
+# Score upcoming matchweek + save predictions to DB (legacy)
 python src/serve.py predict
 
-# Record actual results + view live P&L
+# Record actual results + view live P&L (legacy)
 python src/monitor.py record-actuals
 python src/monitor.py report
-
-# Start FastAPI server
-python src/serve.py
 
 # Run tests
 pytest tests/ -v --cov=src
@@ -85,25 +104,37 @@ mlflow ui --backend-store-uri sqlite:///mlflow.db
 
 ## Architecture
 
-A scheduled ML pipeline with champion/challenger deployment via the MLflow Model Registry.
+### Current (`src/`, scheduled for deletion in Phase 2)
 
-**Data flow:**
-1. `src/ingest.py` — pulls completed EPL results from football-data.co.uk (no auth) and upcoming fixtures/odds from API-Football (RapidAPI). Processed season CSVs are stored in `data/legacy/data/hist-data/processed/E0-YYYY-YYYY.csv`.
-2. `src/features.py` — single source of truth for all feature construction. Defines feature sets for each model type (`lpm1`, `lpm2`, `glm1`, `glm2`, `xgb`) and computes derived features (`AwayPPG_Last5`, implied probabilities, `OddsRatio`). Import from here — never reimplement feature logic in other modules.
-3. `src/train.py` — loads all processed CSVs, builds features via `features.py`, trains the selected model type, logs metrics + artifact to MLflow (`epl-models` experiment), and promotes to `epl-home-win@champion` if it beats the current champion on both accuracy and ROI.
-4. `src/evaluate.py` — walk-forward backtester. Logs a `roi_curve.csv` artifact to the `epl-backtest` experiment for visualising cumulative P&L over time.
-5. `src/monitor.py` — persists pre-match predictions and actual results to `data/predictions.db` (SQLite). Computes live ROI after matches are played and logs snapshots to the `epl-monitoring` experiment.
-6. `src/serve.py` — FastAPI app + CLI batch predictor. Loads `epl-home-win@champion` from the registry, scores upcoming fixtures via `features.build_predict_features`, and writes predictions to the monitor DB.
+A scheduled ML pipeline with champion/challenger deployment via the MLflow Model Registry. Five model families (LPM1, LPM2, GLM1, GLM2, XGB) compete for the `epl-home-win@champion` slot. XGB is the current champion. Built from the original university R model; carries the structural weaknesses called out in the rescope plan (home-win only target, bookmaker-derivative features, fixed flat stake, no leakage guard in the backtest).
 
-**Models:** LPM1, LPM2 (OLS), GLM1, GLM2 (logistic), XGBoost — all compete in the `epl-home-win` registry. Current champion: XGBoost.
+Data flow today:
+1. `src/ingest.py` → football-data.co.uk results + API-Football odds → season CSVs under `data/legacy/data/hist-data/processed/`.
+2. `src/features.py` → `FEATURE_SETS` per model type; computes `HomePPG_Last5`, implied probs, odds ratio.
+3. `src/train.py` → trains a model, registers to `epl-home-win`, promotes to `@champion` if it beats current on accuracy + ROI.
+4. `src/evaluate.py` → walk-forward backtest, ROI curve artifact.
+5. `src/monitor.py` → SQLite (`data/predictions.db`) prediction + result reconciliation, live P&L.
+6. `src/serve.py` → FastAPI + CLI batch predictor.
 
-**Legacy:** `legacy/` contains the original R model the Python pipeline was ported from. `data/legacy/` contains historical CSVs and cleaning notebooks.
+### Target (`platform/`, Phase 1 onward)
 
-**Designed to extend:** the seams where Phase 2/3 scope will plug in.
+```
+platform/
+  db/            SQLite schema + migrations
+  ingest/        ingest_matches.py, ingest_odds.py (parameterised by league/season/book/market)
+  features/      one module per feature family (ppg.py, implied_prob.py, elo.py, xg.py, …)
+  strategies/    Strategy config dataclass + registered strategies
+  backtest/      walk-forward harness — leakage guard, transaction costs, Kelly sizing
+  serve/         CLI batch scorer (FastAPI optional, later)
+  monitor/       drift + live P&L per strategy
+  ui/            Streamlit pages
+```
 
-- **Registry naming.** Today: `epl-home-win` (multi-model, `MULTI_REGISTERED_MODEL_NAME` in `src/train.py:53`) and a backward-compat `epl-home-win-lpm2` (`REGISTERED_MODEL_NAME` in `src/train.py:51`). Serving falls back from one to the other (`DEFAULT_MODEL_NAME` / `FALLBACK_MODEL_NAME` in `src/serve.py:46-47`). Future shape: `{league}-{market}` (e.g. `epl-draw`, `laliga-home-win`). Those four constants are the points that bake `epl-home-win` in — change them together.
-- **Feature module.** `src/features.py` centralises `FEATURE_SETS` keyed by model type. New markets should add new keys (e.g. `xgb_draw`) alongside the existing `lpm1/lpm2/glm1/glm2/xgb`, not replace them. Keep features league-agnostic where possible — PPG-style features generalise; bookmaker-specific columns like `B365H` may not.
-- **Ingest.** `src/ingest.py` hardcodes EPL endpoints. A future refactor will need a `league` parameter; not blocking now.
+Registered unit in MLflow becomes the **strategy**, not the model: `strategy/{slug}@champion`. The model is one component inside the strategy artifact, alongside the feature set, sizing rule, and target market.
+
+The legacy `data/legacy/data/hist-data/processed/E0-*.csv` files become the bootstrap input for `ingest_matches` — once in SQLite, the CSVs are no longer load-bearing.
+
+**Legacy:** `legacy/` contains the original R model the Python pipeline was ported from. Kept as historical archive.
 
 ## Git Workflow
 
@@ -113,10 +144,10 @@ A scheduled ML pipeline with champion/challenger deployment via the MLflow Model
 
 | Prefix | When to use | Example |
 |--------|-------------|---------|
-| `feat/` | New functionality | `feat/drift-monitoring` |
-| `bug/` | Fix a defect | `bug/ppg-rolling-window` |
-| `dev/` | Exploratory or WIP work | `dev/xgb-hyperparameter-search` |
-| `docs/` | Docs-only change | `docs/reframe-product-aims` |
+| `feat/` | New functionality | `feat/platform-foundations` |
+| `bug/` | Fix a defect | `bug/leakage-in-rolling-features` |
+| `dev/` | Exploratory or WIP work | `dev/xg-feature-module` |
+| `docs/` | Docs-only change | `docs/rescope-platform` |
 
 ### Workflow
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -2,28 +2,37 @@
 
 ## Product
 
-An EPL match-prediction service. It produces probability-calibrated pre-match bets, reconciles them against actual results for a live ROI figure, and runs on a schedule (refresh data → retrain when warranted → score next matchweek → monitor drift). Intended for a small private user group; openable later, but not optimised for that today.
+A **betting-strategy research platform**. Pipeline for ingesting match data + odds, defining strategies, backtesting them honestly, tracking live performance. Local-only today; the existing XGB home-win model becomes `strategy_v1`, one strategy among many to come.
+
+## Core abstraction
+
+> **Strategy = feature set + model + sizing rule + target market.**
+
+The platform is the product. Strategies are content. New theory → one feature module + one strategy config → honest backtest → optional live tracking.
 
 ## Goals
 
-1. Correct, calibrated home-win predictions for EPL with reproducible training, walk-forward backtests, and live ROI reconciliation.
-2. Operational reliability — drift monitoring, scheduled retraining, scheduled scoring.
-3. Extensible architecture — a new league or bet-type plugs in, doesn't require a rewrite.
-4. Shareable when ready — a small auth + UI step away from opening up to more users.
+1. Cheap to test a new strategy: define config → backtest → answer.
+2. Honest backtests: walk-forward, leakage-guarded, transaction-cost-aware, Kelly-aware sizing.
+3. Apples-to-apples comparison between strategies by construction.
+4. Extensible — new leagues / books / markets / features plug in as config + small modules.
+5. Shareable when ready — local-only today, a small step to multi-user later.
 
 ## Non-goals
 
-- Public SaaS, billing, multi-tenant.
-- Live/in-play scoring.
-- Bankroll management, Kelly sizing, automated bet execution.
-- Bet types beyond home-win (roadmap).
-- Leagues beyond EPL (roadmap).
+- Real-money execution.
+- Public SaaS, billing, multi-tenant, always-on hosting.
+- Live / in-play scoring.
+- Making the model look good before the platform is honest.
+- Polish on legacy `src/` modules — they're scheduled for deletion (Roadmap Phase 2).
 
 ## Roadmap
 
-- **Phase 1 — Operational hardening (now):** Evidently drift monitoring; scheduled retraining + scoring; GitHub Actions CI.
-- **Phase 2 — Model scope:** additional EPL bet types (draw, away-win, O/U 2.5, BTTS); calibration check.
-- **Phase 3 — League scope:** generalise ingest + features + registry to a second league.
-- **Phase 4 — Sharing:** lightweight auth, multi-user view, always-on hosting.
+- **Phase 1 — Platform foundations:** SQLite schema + migrations; `platform/ingest/` (matches + odds, parameterised); first feature modules (PPG, implied prob, odds ratio); walk-forward backtest harness with leakage guard + transaction costs + Kelly-aware sizing.
+- **Phase 2 — Strategy abstraction + `strategy_v1`:** versioned `Strategy` config; port XGB home-win as `strategy_v1`; delete legacy `src/train.py` / `src/serve.py` / `src/monitor.py` / `src/evaluate.py` + LPM/GLM model families.
+- **Phase 3 — Streamlit UI:** strategy gallery + detail + this-week + add-strategy.
+- **Phase 4 — Ops:** scheduled ingest + scheduled scoring; per-strategy drift; GH Actions CI.
+- **Phase 5 — Strategy expansion:** each new theory = one feature module + one strategy config.
+- **Phase 6 — Multi-league:** add a second league via config + ingest params, not code.
 
-See `CLAUDE.md` for architecture, commands, and the extensibility seams.
+See `CLAUDE.md` for the target `platform/` layout, the registry-naming scheme, and the file:line seams that still bake `epl-home-win` into the legacy `src/` modules.

--- a/README.md
+++ b/README.md
@@ -1,49 +1,36 @@
-# EPL Match Prediction System
+# Betting-Strategy Research Platform
 
-A small EPL match-prediction service. It produces probability-calibrated pre-match bets, reconciles them against actual results for a live ROI figure, and runs on a schedule — refresh data, retrain when warranted, score the upcoming matchweek, monitor drift.
+A local pipeline for ingesting match data + odds, defining betting strategies, backtesting them honestly, and tracking live performance. Originally a port of a university EPL home-win model — now rescoped around the platform itself, with the original model becoming one strategy plugged in.
 
-Current scope is **EPL home-win**. The architecture (registry naming, feature sets, ingest) is designed so additional bet types and additional leagues plug in without a rewrite. See `CLAUDE.md` for the extensibility seams and the phased roadmap.
+## Core abstraction
 
-## Architecture
+> **Strategy = feature set + model + sizing rule + target market.**
 
-```
-football-data.co.uk  ──►  ingest.py  ──►  features.py  ──►  train.py
-API-Football (odds)                                              │
-                                                                 ▼
-                                                        MLflow Model Registry
-                                                        (epl-home-win@champion)
-                                                                 │
-                                              ┌──────────────────┼──────────────────┐
-                                              ▼                  ▼                  ▼
-                                         serve.py          evaluate.py         monitor.py
-                                    (FastAPI + CLI)     (walk-forward       (SQLite P&L
-                                                          backtest)           tracker)
-```
+The existing XGBoost home-win setup is `strategy_v1`. Future strategies (Elo + rest days → Poisson goals → fractional Kelly → over 2.5, etc.) are added as a small feature module + a strategy config — the platform itself doesn't change. Every strategy shares the same ingest, the same walk-forward backtest harness, the same UI for comparison.
 
-| Component | What it does |
-|-----------|-------------|
-| `src/ingest.py` | Fetches completed EPL results (football-data.co.uk, free) and upcoming fixture odds (API-Football, RapidAPI) |
-| `src/features.py` | Feature engineering — `AwayPPG_Last5`, implied probabilities, odds ratio — shared by training and serving |
-| `src/train.py` | Trains any of 5 model types with MLflow tracking; promotes champion if it beats current on both accuracy and ROI |
-| `src/evaluate.py` | Walk-forward backtester — produces a cumulative ROI curve artifact in MLflow |
-| `src/monitor.py` | Persists pre-match predictions + actual results to SQLite; computes live P&L |
-| `src/serve.py` | FastAPI endpoint + CLI batch predictor; loads champion from registry |
+See `CLAUDE.md` for the target architecture (`platform/` layout, registry naming, transition details).
 
-## Models
+## Status
 
-Five architectures compete in the `epl-home-win` MLflow registry:
+The platform is being built greenfield. The legacy `src/` modules (`train.py`, `serve.py`, `monitor.py`, `evaluate.py`, plus LPM/GLM model families) still run today and will be deleted in Phase 2 of the roadmap below.
 
-| Type | Algorithm | Features |
-|------|-----------|---------|
-| `lpm2` | OLS (linear probability) | B365H, HomePPG_Last5 |
-| `lpm1` | OLS (linear probability) | All odds + both form + implied probs + ratio |
-| `glm2` | Logistic regression | ImpliedH, HomePPG_Last5 |
-| `glm1` | Logistic regression | All odds + both form + implied probs + ratio |
-| `xgb` | XGBoost | All odds + both form + implied probs + ratio |
+## Roadmap
 
-Current champion: **XGBoost** — 79.8% accuracy, 43.2% ROI (static hold-out).
+- **Phase 1 — Platform foundations (now):** SQLite schema; `platform/ingest/` (matches + odds, parameterised by league/season/book/market); first feature modules (PPG, implied prob, odds ratio); walk-forward backtest harness with leakage guard, transaction costs, and Kelly-aware sizing.
+- **Phase 2 — Strategy abstraction + `strategy_v1`:** versioned `Strategy` config; port the existing XGB home-win as `strategy_v1`; delete legacy `src/` modules + LPM/GLM model families.
+- **Phase 3 — Streamlit UI:** strategy gallery, strategy detail (equity curve + calibration + recent picks), this-week scoreboard, add-strategy flow.
+- **Phase 4 — Ops:** scheduled ingest + scheduled scoring; drift detection per strategy; GitHub Actions CI for tests + lint.
+- **Phase 5 — Strategy expansion:** each new theory = one feature module + one strategy config.
+- **Phase 6 — Multi-league:** add a second league via config + ingest params, not code.
 
-Betting strategy: fixed £100 stake when model probability ≥ threshold (default 0.5). ROI = net profit / total staked × 100.
+## Stack
+
+- **Storage:** SQLite (local, single file). Postgres deferred until multi-user.
+- **Modelling:** scikit-learn + XGBoost for `strategy_v1`; future strategies can bring their own.
+- **Tracking:** MLflow — the registered unit is the *strategy*, not the model.
+- **Backtest:** custom walk-forward harness (leakage guard + transaction costs + Kelly sizing). No static hold-out.
+- **Serving:** CLI batch scorer. FastAPI optional later.
+- **UI:** Streamlit.
 
 ## Setup
 
@@ -58,28 +45,29 @@ Required env vars (`.env`):
 API_KEY=<RapidAPI key for api-football-v1.p.rapidapi.com>
 ```
 
-## Usage
+## Usage (legacy `src/`)
+
+These commands operate on the legacy pipeline and will be deleted in Phase 2. Documented here so the system remains runnable during the transition.
 
 ```bash
 # Refresh current-season data
 python src/ingest.py recent
 
-# Train all 5 model types (promotes champion automatically)
+# Train (legacy multi-model)
 python src/train.py --all
 
-# Walk-forward backtest + ROI curve in MLflow
+# Walk-forward backtest (legacy)
 python src/evaluate.py compare
 
-# Score next matchweek + save predictions to DB
+# Score next matchweek (legacy)
 python src/serve.py predict
 
-# After matches play — record results and view live P&L
+# Record results and view live P&L (legacy)
 python src/monitor.py record-actuals
 python src/monitor.py report
-
-# Start FastAPI server
-python src/serve.py           # → localhost:8000
 ```
+
+New `platform/` commands will be added here as Phase 1 lands.
 
 ## MLflow UI
 
@@ -87,21 +75,12 @@ python src/serve.py           # → localhost:8000
 mlflow ui --backend-store-uri sqlite:///mlflow.db
 ```
 
-Experiments: `epl-models` (training runs), `epl-backtest` (walk-forward), `epl-monitoring` (live P&L snapshots).
-
 ## Tests
 
 ```bash
 pytest tests/ -v --cov=src
 ```
 
-44 tests covering feature engineering, the SQLite P&L tracker, ROI/classify logic, and FastAPI endpoints (mocked registry calls).
+44 tests cover the legacy `src/` modules — feature engineering, the SQLite P&L tracker, ROI/classify logic, and FastAPI endpoints (mocked registry calls). New tests will land alongside `platform/` modules.
 
-## Roadmap
-
-- **Phase 1 — Operational hardening (now):** Evidently AI drift monitoring; scheduled retraining + scheduled matchweek scoring; GitHub Actions CI.
-- **Phase 2 — Model scope:** additional EPL bet types (draw, away-win, O/U 2.5, BTTS); calibration check.
-- **Phase 3 — League scope:** generalise ingest + features + registry to a second league.
-- **Phase 4 — Sharing:** lightweight auth, multi-user prediction view, always-on hosting.
-
-`legacy/` contains the original R model the Python pipeline was ported from. `data/legacy/` contains historical CSVs and cleaning notebooks.
+`legacy/` contains the original R model the Python pipeline was ported from. `data/legacy/data/hist-data/processed/E0-*.csv` are the historical CSVs, which Phase 1 will use to bootstrap the SQLite store.


### PR DESCRIPTION
## Summary

Rescopes the project away from "production EPL home-win predictor" toward **a betting-strategy research platform** — a pipeline for ingesting match data + odds, defining strategies, backtesting them honestly, and tracking live performance. The existing XGB home-win model becomes \`strategy_v1\`, one strategy plugged into the new pipeline.

### Why

The previous reframing (PRs #13 #14) cleaned up the docs but kept the same model-first shape. On closer look, the rebuild had inherited the original uni model's weaknesses: home-win-only target, bookmaker-derivative features, fixed flat stake, no leakage guard. Hardening operations on top of a model we don't believe in is wasted work. Pivoting to a pipeline-first design lets us test strategies honestly as they're proposed, rather than polishing one suspect strategy.

### What changes

- **Core abstraction:** *Strategy = feature set + model + sizing rule + target market.*
- **Goals** rewritten around cheap-to-test strategies, honest backtests, apples-to-apples comparison, extensibility, optional later sharing.
- **Non-goals** updated: no real-money execution, no SaaS, no live in-play, no polish on legacy \`src/\` before deletion.
- **Roadmap** replaced with 6 phases:
  1. Platform foundations — SQLite schema, parameterised ingest, feature modules, walk-forward backtest harness with leakage guard + transaction costs + Kelly-aware sizing.
  2. Strategy abstraction + \`strategy_v1\` — port XGB home-win, delete legacy \`src/\` + LPM/GLM families.
  3. Streamlit research UI.
  4. Ops — scheduling, per-strategy drift, CI.
  5. Strategy expansion — each theory = one feature module + one strategy config.
  6. Multi-league.
- **Stack locked:** SQLite + Streamlit + MLflow (with *strategy* as the registered unit, not model) + Kelly-aware sizing from day one.
- **Migration approach:** greenfield port-forward. Legacy \`src/\` runs until Phase 2 then gets deleted. No strangler-fig.

### What's preserved

- Legacy \`src/\` architecture description and Common Commands sections in CLAUDE.md / README.md — kept so the system remains runnable during the transition, but explicitly labelled as scheduled for deletion in Phase 2.
- Legacy R model in \`legacy/\` — historical archive, unchanged.

### Follow-up PRs

This is docs-only. Next:

- \`feat/platform-foundations\` — scaffold the \`platform/\` package + SQLite schema (Phase 1 starts here).

## Test plan
- [ ] Read \`CLAUDE.md\`, \`CONTEXT.md\`, \`README.md\` end-to-end. A fresh Claude session opening any of them should understand the platform-first framing, the Strategy abstraction, what's scheduled for deletion, and the phased roadmap.
- [ ] \`grep -rniE "interview|portfolio|LEGO" .\` returns zero matches. (Two intentional "university" mentions remain — one acknowledging project origin in README lead, one in the legacy-arch description in CLAUDE.md explaining what's being phased out.)
- [ ] Legacy \`Common Commands\` section in CLAUDE.md still matches reality — no behaviour changes in this PR, sanity check only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)