### PR TITLE
feat: scaffold bsrp package with SQLite schema + migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ __pycache__/
 # MLflow local DB
 mlflow.db
 
+# BSRP local DB
+bsrp.db
+
 # Pytest cache
 .pytest_cache/
 .coverage

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,9 +42,9 @@ The previous home-win-focused roadmap is superseded. New phases:
 
 - **Phase 1 — Platform foundations (now):**
   - SQLite schema (`matches`, `odds_snapshots`, `features`, `strategies`, `backtest_runs`, `live_predictions`, `settled_bets`) + migrations.
-  - `platform/ingest/` — `ingest_matches` (football-data.co.uk) and `ingest_odds` (API-Football), idempotent, parameterised by `(league, season, book, market)`.
-  - `platform/features/` — feature modules (PPG, implied prob, odds ratio to start; Elo / xG / rest later).
-  - `platform/backtest/` — walk-forward harness with leakage guard, transaction costs, Kelly-aware sizing interface.
+  - `bsrp/ingest/` — `ingest_matches` (football-data.co.uk) and `ingest_odds` (API-Football), idempotent, parameterised by `(league, season, book, market)`.
+  - `bsrp/features/` — feature modules (PPG, implied prob, odds ratio to start; Elo / xG / rest later).
+  - `bsrp/backtest/` — walk-forward harness with leakage guard, transaction costs, Kelly-aware sizing interface.
 - **Phase 2 — Strategy abstraction + `strategy_v1`:**
   - Define `Strategy` as a versioned config object (feature set + model URI + sizing rule + market).
   - Port the existing XGB home-win as `strategy_v1`. End-to-end backtest under honest conditions.
@@ -69,11 +69,11 @@ Secrets go in `.env` (gitignored). Required keys:
 - `API_KEY` — RapidAPI key for API-Football
 - `HOST` — defaults to `api-football-v1.p.rapidapi.com`
 
-MLflow uses a local SQLite backend (`mlflow.db`) and artifact store (`mlruns/`, gitignored). The platform's own data lives in a separate SQLite DB (`platform.db`, also gitignored, created by Phase 1).
+MLflow uses a local SQLite backend (`mlflow.db`) and artifact store (`mlruns/`, gitignored). The platform's own data lives in a separate SQLite DB (`bsrp.db`, also gitignored, created by Phase 1).
 
 ## Common Commands
 
-> **Note:** the commands below operate on the legacy `src/` pipeline. They still work today and will be deleted in Phase 2. New `platform/` commands will be documented here as each phase lands.
+> **Note:** the commands below operate on the legacy `src/` pipeline. They still work today and will be deleted in Phase 2. New `bsrp/` commands will be documented here as each phase lands.
 
 ```bash
 # Ingest recent completed fixtures (refreshes current-season CSV)
@@ -116,11 +116,14 @@ Data flow today:
 5. `src/monitor.py` → SQLite (`data/predictions.db`) prediction + result reconciliation, live P&L.
 6. `src/serve.py` → FastAPI + CLI batch predictor.
 
-### Target (`platform/`, Phase 1 onward)
+### Target (`bsrp/`, Phase 1 onward)
+
+The package is named `bsrp` (Betting Strategy Research Platform) rather than `platform` to avoid shadowing Python's stdlib `platform` module — using a stdlib name as a package would silently break any code that imports stdlib `platform` from inside the repo.
 
 ```
-platform/
-  db/            SQLite schema + migrations
+bsrp/
+  __main__.py    python -m bsrp <command>
+  db/            SQLite schema + migrations (Phase 1, done)
   ingest/        ingest_matches.py, ingest_odds.py (parameterised by league/season/book/market)
   features/      one module per feature family (ppg.py, implied_prob.py, elo.py, xg.py, …)
   strategies/    Strategy config dataclass + registered strategies
@@ -128,6 +131,12 @@ platform/
   serve/         CLI batch scorer (FastAPI optional, later)
   monitor/       drift + live P&L per strategy
   ui/            Streamlit pages
+```
+
+Phase 1 commands (now available):
+
+```bash
+python -m bsrp init-db          # create or upgrade the local SQLite store at bsrp.db
 ```
 
 Registered unit in MLflow becomes the **strategy**, not the model: `strategy/{slug}@champion`. The model is one component inside the strategy artifact, alongside the feature set, sizing rule, and target market.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,11 +28,11 @@ The platform is the product. Strategies are content. New theory → one feature 
 
 ## Roadmap
 
-- **Phase 1 — Platform foundations:** SQLite schema + migrations; `platform/ingest/` (matches + odds, parameterised); first feature modules (PPG, implied prob, odds ratio); walk-forward backtest harness with leakage guard + transaction costs + Kelly-aware sizing.
+- **Phase 1 — Platform foundations:** SQLite schema + migrations; `bsrp/ingest/` (matches + odds, parameterised); first feature modules (PPG, implied prob, odds ratio); walk-forward backtest harness with leakage guard + transaction costs + Kelly-aware sizing.
 - **Phase 2 — Strategy abstraction + `strategy_v1`:** versioned `Strategy` config; port XGB home-win as `strategy_v1`; delete legacy `src/train.py` / `src/serve.py` / `src/monitor.py` / `src/evaluate.py` + LPM/GLM model families.
 - **Phase 3 — Streamlit UI:** strategy gallery + detail + this-week + add-strategy.
 - **Phase 4 — Ops:** scheduled ingest + scheduled scoring; per-strategy drift; GH Actions CI.
 - **Phase 5 — Strategy expansion:** each new theory = one feature module + one strategy config.
 - **Phase 6 — Multi-league:** add a second league via config + ingest params, not code.
 
-See `CLAUDE.md` for the target `platform/` layout, the registry-naming scheme, and the file:line seams that still bake `epl-home-win` into the legacy `src/` modules.
+See `CLAUDE.md` for the `bsrp/` package layout, the registry-naming scheme, and the file:line seams that still bake `epl-home-win` into the legacy `src/` modules. The package is named `bsrp` (not `platform`) to avoid shadowing Python's stdlib `platform` module.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A local pipeline for ingesting match data + odds, defining betting strategies, b
 
 The existing XGBoost home-win setup is `strategy_v1`. Future strategies (Elo + rest days → Poisson goals → fractional Kelly → over 2.5, etc.) are added as a small feature module + a strategy config — the platform itself doesn't change. Every strategy shares the same ingest, the same walk-forward backtest harness, the same UI for comparison.
 
-See `CLAUDE.md` for the target architecture (`platform/` layout, registry naming, transition details).
+See `CLAUDE.md` for the target architecture (`bsrp/` package layout, registry naming, transition details).
 
 ## Status
 
@@ -16,7 +16,7 @@ The platform is being built greenfield. The legacy `src/` modules (`train.py`, `
 
 ## Roadmap
 
-- **Phase 1 — Platform foundations (now):** SQLite schema; `platform/ingest/` (matches + odds, parameterised by league/season/book/market); first feature modules (PPG, implied prob, odds ratio); walk-forward backtest harness with leakage guard, transaction costs, and Kelly-aware sizing.
+- **Phase 1 — Platform foundations (now):** SQLite schema; `bsrp/ingest/` (matches + odds, parameterised by league/season/book/market); first feature modules (PPG, implied prob, odds ratio); walk-forward backtest harness with leakage guard, transaction costs, and Kelly-aware sizing.
 - **Phase 2 — Strategy abstraction + `strategy_v1`:** versioned `Strategy` config; port the existing XGB home-win as `strategy_v1`; delete legacy `src/` modules + LPM/GLM model families.
 - **Phase 3 — Streamlit UI:** strategy gallery, strategy detail (equity curve + calibration + recent picks), this-week scoreboard, add-strategy flow.
 - **Phase 4 — Ops:** scheduled ingest + scheduled scoring; drift detection per strategy; GitHub Actions CI for tests + lint.
@@ -67,7 +67,12 @@ python src/monitor.py record-actuals
 python src/monitor.py report
 ```
 
-New `platform/` commands will be added here as Phase 1 lands.
+New `bsrp/` commands will be added here as Phase 1 lands. The package is named `bsrp` (not `platform`) so it doesn't shadow Python's stdlib `platform` module.
+
+```bash
+# Already available (Phase 1, just landed):
+python -m bsrp init-db          # create or upgrade the local SQLite store
+```
 
 ## MLflow UI
 
@@ -81,6 +86,6 @@ mlflow ui --backend-store-uri sqlite:///mlflow.db
 pytest tests/ -v --cov=src
 ```
 
-44 tests cover the legacy `src/` modules — feature engineering, the SQLite P&L tracker, ROI/classify logic, and FastAPI endpoints (mocked registry calls). New tests will land alongside `platform/` modules.
+44 tests cover the legacy `src/` modules — feature engineering, the SQLite P&L tracker, ROI/classify logic, and FastAPI endpoints (mocked registry calls). 8 more cover the `bsrp/` SQLite store (Phase 1).
 
 `legacy/` contains the original R model the Python pipeline was ported from. `data/legacy/data/hist-data/processed/E0-*.csv` are the historical CSVs, which Phase 1 will use to bootstrap the SQLite store.

--- a/bsrp/__init__.py
+++ b/bsrp/__init__.py
@@ -1,0 +1,7 @@
+"""bsrp — Betting Strategy Research Platform.
+
+Pipeline for ingesting match data + odds, defining strategies, backtesting them
+honestly, and tracking live performance. See CLAUDE.md for the architecture.
+"""
+
+__version__ = "0.1.0"

--- a/bsrp/__main__.py
+++ b/bsrp/__main__.py
@@ -1,0 +1,40 @@
+"""CLI entry point: python -m bsrp <command>"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+from bsrp.db.connection import connect, get_db_path
+from bsrp.db.migrate import run_migrations
+
+
+def _cmd_init_db() -> None:
+    path = get_db_path()
+    print(f"Initialising BSRP store at {path}")
+    with connect() as conn:
+        applied = run_migrations(conn)
+    if applied:
+        print(f"Applied {len(applied)} migration(s): {', '.join(applied)}")
+    else:
+        print("Already up to date.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="bsrp")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("init-db", help="Create or upgrade the BSRP SQLite store")
+
+    args = parser.parse_args()
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s — %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    if args.command == "init-db":
+        _cmd_init_db()
+
+
+if __name__ == "__main__":
+    main()

--- a/bsrp/db/__init__.py
+++ b/bsrp/db/__init__.py
@@ -1,0 +1,6 @@
+"""Database layer — SQLite store for matches, odds, features, strategies, runs."""
+
+from bsrp.db.connection import connect, get_db_path
+from bsrp.db.migrate import run_migrations, discover_migrations
+
+__all__ = ["connect", "get_db_path", "run_migrations", "discover_migrations"]

--- a/bsrp/db/connection.py
+++ b/bsrp/db/connection.py
@@ -1,0 +1,42 @@
+"""SQLite connection management.
+
+Default DB path is `bsrp.db` at the repo root; override via the `BSRP_DB_PATH`
+environment variable. Foreign keys are enabled per-connection (SQLite's default
+is off).
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import sqlite3
+from contextlib import contextmanager
+from typing import Iterator
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+DEFAULT_DB_PATH = _REPO_ROOT / "bsrp.db"
+
+
+def get_db_path() -> pathlib.Path:
+    return pathlib.Path(os.environ.get("BSRP_DB_PATH", DEFAULT_DB_PATH))
+
+
+@contextmanager
+def connect(db_path: pathlib.Path | None = None) -> Iterator[sqlite3.Connection]:
+    """Open a SQLite connection with FK enforcement + Row factory.
+
+    Commits on clean exit, rolls back on exception, always closes.
+    """
+    path = db_path or get_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()

--- a/bsrp/db/migrate.py
+++ b/bsrp/db/migrate.py
@@ -1,0 +1,53 @@
+"""Forward-only SQL migrations.
+
+Migration files live in `bsrp/db/migrations/` as `NNN_name.sql`. They are
+applied in filename order. Applied versions are tracked in `schema_migrations`,
+which the first migration creates.
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import sqlite3
+
+logger = logging.getLogger(__name__)
+
+_MIGRATIONS_DIR = pathlib.Path(__file__).resolve().parent / "migrations"
+
+
+def discover_migrations(
+    migrations_dir: pathlib.Path = _MIGRATIONS_DIR,
+) -> list[pathlib.Path]:
+    """Return migration files sorted by filename."""
+    return sorted(migrations_dir.glob("[0-9]*.sql"))
+
+
+def _applied_versions(conn: sqlite3.Connection) -> set[str]:
+    try:
+        rows = conn.execute("SELECT version FROM schema_migrations").fetchall()
+        return {row[0] for row in rows}
+    except sqlite3.OperationalError:
+        return set()
+
+
+def run_migrations(
+    conn: sqlite3.Connection,
+    migrations_dir: pathlib.Path = _MIGRATIONS_DIR,
+) -> list[str]:
+    """Apply pending migrations in order. Returns versions newly applied."""
+    applied = _applied_versions(conn)
+    newly_applied: list[str] = []
+    for migration in discover_migrations(migrations_dir):
+        version = migration.stem
+        if version in applied:
+            continue
+        logger.info("Applying migration %s", version)
+        conn.executescript(migration.read_text())
+        conn.execute(
+            "INSERT INTO schema_migrations (version) VALUES (?)",
+            (version,),
+        )
+        newly_applied.append(version)
+    conn.commit()
+    return newly_applied

--- a/bsrp/db/migrations/001_initial_schema.sql
+++ b/bsrp/db/migrations/001_initial_schema.sql
@@ -1,0 +1,106 @@
+-- 001_initial_schema.sql
+-- Initial BSRP store: matches, odds snapshots, sparse features, strategies,
+-- backtest runs, live predictions, settled bets.
+
+CREATE TABLE IF NOT EXISTS schema_migrations (
+    version     TEXT PRIMARY KEY,
+    applied_at  TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- League-agnostic match facts. match_id is a deterministic hash of
+-- (league, season, date, home, away) computed in code, so re-ingesting
+-- the same source data is idempotent.
+CREATE TABLE matches (
+    match_id        TEXT PRIMARY KEY,
+    league          TEXT NOT NULL,
+    season          TEXT NOT NULL,
+    date            TEXT NOT NULL,
+    home            TEXT NOT NULL,
+    away            TEXT NOT NULL,
+    ft_home_goals   INTEGER,
+    ft_away_goals   INTEGER,
+    result          TEXT CHECK (result IN ('H', 'D', 'A') OR result IS NULL),
+    UNIQUE (league, season, date, home, away)
+);
+CREATE INDEX idx_matches_league_season ON matches (league, season);
+CREATE INDEX idx_matches_date ON matches (date);
+
+-- Multi-book, multi-market odds. Time-series capable: a single match can
+-- have many snapshots from the same book to track line movement.
+CREATE TABLE odds_snapshots (
+    snapshot_id     INTEGER PRIMARY KEY AUTOINCREMENT,
+    match_id        TEXT NOT NULL REFERENCES matches(match_id),
+    market          TEXT NOT NULL,
+    book            TEXT NOT NULL,
+    captured_at     TEXT NOT NULL,
+    outcome         TEXT NOT NULL,
+    decimal_odds    REAL NOT NULL CHECK (decimal_odds > 1.0),
+    UNIQUE (match_id, market, book, captured_at, outcome)
+);
+CREATE INDEX idx_odds_match ON odds_snapshots (match_id);
+CREATE INDEX idx_odds_market ON odds_snapshots (market);
+
+-- Sparse feature store: one row per (match, feature). Feature modules
+-- own their feature_name namespace. Re-running a feature module overwrites
+-- (PK conflict → INSERT OR REPLACE).
+CREATE TABLE features (
+    match_id        TEXT NOT NULL REFERENCES matches(match_id),
+    feature_name    TEXT NOT NULL,
+    value           REAL NOT NULL,
+    computed_at     TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (match_id, feature_name)
+);
+
+-- Versioned strategy registry. config_json holds the full Strategy spec
+-- (feature set, model URI, sizing rule, target market).
+CREATE TABLE strategies (
+    strategy_id     INTEGER PRIMARY KEY AUTOINCREMENT,
+    slug            TEXT NOT NULL,
+    version         INTEGER NOT NULL,
+    config_json     TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'draft'
+                    CHECK (status IN ('draft', 'active', 'retired')),
+    created_at      TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (slug, version)
+);
+
+-- Backtest results, one row per run.
+CREATE TABLE backtest_runs (
+    run_id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    strategy_id         INTEGER NOT NULL REFERENCES strategies(strategy_id),
+    start_date          TEXT NOT NULL,
+    end_date            TEXT NOT NULL,
+    n_bets              INTEGER NOT NULL,
+    total_staked        REAL NOT NULL,
+    total_returned      REAL NOT NULL,
+    roi                 REAL NOT NULL,
+    sharpe              REAL,
+    max_drawdown        REAL,
+    equity_curve_json   TEXT NOT NULL,
+    created_at          TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_backtest_strategy ON backtest_runs (strategy_id);
+
+-- Pre-match predictions + Kelly-sized stake recommendations.
+CREATE TABLE live_predictions (
+    prediction_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    strategy_id         INTEGER NOT NULL REFERENCES strategies(strategy_id),
+    match_id            TEXT NOT NULL REFERENCES matches(match_id),
+    market              TEXT NOT NULL,
+    outcome             TEXT NOT NULL,
+    probability         REAL NOT NULL CHECK (probability BETWEEN 0 AND 1),
+    odds_at_prediction  REAL CHECK (odds_at_prediction > 1.0 OR odds_at_prediction IS NULL),
+    recommended_stake   REAL NOT NULL CHECK (recommended_stake >= 0),
+    predicted_at        TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (strategy_id, match_id, market, outcome)
+);
+CREATE INDEX idx_live_pred_strategy ON live_predictions (strategy_id);
+CREATE INDEX idx_live_pred_match ON live_predictions (match_id);
+
+-- Settled bet outcomes, joined back to live_predictions for live P&L.
+CREATE TABLE settled_bets (
+    prediction_id       INTEGER PRIMARY KEY REFERENCES live_predictions(prediction_id),
+    actual_outcome_hit  INTEGER NOT NULL CHECK (actual_outcome_hit IN (0, 1)),
+    pnl                 REAL NOT NULL,
+    settled_at          TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/tests/test_bsrp_db.py
+++ b/tests/test_bsrp_db.py
@@ -1,0 +1,144 @@
+"""Tests for the BSRP SQLite store: connection, migrations, schema, FKs."""
+
+from __future__ import annotations
+
+import pathlib
+import sqlite3
+import tempfile
+
+import pytest
+
+from bsrp.db.connection import connect
+from bsrp.db.migrate import discover_migrations, run_migrations
+
+
+EXPECTED_TABLES = {
+    "schema_migrations",
+    "matches",
+    "odds_snapshots",
+    "features",
+    "strategies",
+    "backtest_runs",
+    "live_predictions",
+    "settled_bets",
+}
+
+
+@pytest.fixture
+def temp_db_path():
+    with tempfile.TemporaryDirectory() as tmp:
+        yield pathlib.Path(tmp) / "test.db"
+
+
+def test_at_least_one_migration_discoverable():
+    migrations = discover_migrations()
+    assert len(migrations) >= 1
+    assert all(m.suffix == ".sql" for m in migrations)
+
+
+def test_run_migrations_creates_schema(temp_db_path):
+    with connect(temp_db_path) as conn:
+        applied = run_migrations(conn)
+    assert "001_initial_schema" in applied
+
+    with connect(temp_db_path) as conn:
+        rows = conn.execute("SELECT version FROM schema_migrations").fetchall()
+    versions = {row[0] for row in rows}
+    assert "001_initial_schema" in versions
+
+
+def test_run_migrations_is_idempotent(temp_db_path):
+    with connect(temp_db_path) as conn:
+        run_migrations(conn)
+    with connect(temp_db_path) as conn:
+        second_run = run_migrations(conn)
+    assert second_run == []
+
+
+def test_all_expected_tables_present(temp_db_path):
+    with connect(temp_db_path) as conn:
+        run_migrations(conn)
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+    found = {row[0] for row in rows}
+    missing = EXPECTED_TABLES - found
+    assert not missing, f"missing tables: {missing}"
+
+
+def test_foreign_keys_are_enforced(temp_db_path):
+    with connect(temp_db_path) as conn:
+        run_migrations(conn)
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO odds_snapshots "
+                "(match_id, market, book, captured_at, outcome, decimal_odds) "
+                "VALUES ('nonexistent_match', '1X2', 'Bet365', "
+                "'2026-01-01T12:00:00', 'H', 2.10)"
+            )
+
+
+def test_match_insert_and_unique_constraint(temp_db_path):
+    with connect(temp_db_path) as conn:
+        run_migrations(conn)
+        conn.execute(
+            "INSERT INTO matches "
+            "(match_id, league, season, date, home, away, "
+            " ft_home_goals, ft_away_goals, result) "
+            "VALUES (?, 'EPL', '2024-2025', '2024-08-16', "
+            "'Arsenal', 'Wolves', 2, 0, 'H')",
+            ("m_test_1",),
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO matches "
+                "(match_id, league, season, date, home, away) "
+                "VALUES ('m_test_2', 'EPL', '2024-2025', '2024-08-16', "
+                "'Arsenal', 'Wolves')"
+            )
+
+
+def test_features_primary_key_enforces_one_value_per_feature(temp_db_path):
+    with connect(temp_db_path) as conn:
+        run_migrations(conn)
+        conn.execute(
+            "INSERT INTO matches "
+            "(match_id, league, season, date, home, away) "
+            "VALUES ('m_feat', 'EPL', '2024-2025', '2024-08-16', "
+            "'Arsenal', 'Wolves')"
+        )
+        conn.execute(
+            "INSERT INTO features (match_id, feature_name, value) "
+            "VALUES ('m_feat', 'HomePPG_Last5', 1.8)"
+        )
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO features (match_id, feature_name, value) "
+                "VALUES ('m_feat', 'HomePPG_Last5', 2.1)"
+            )
+
+
+def test_probability_check_constraint(temp_db_path):
+    with connect(temp_db_path) as conn:
+        run_migrations(conn)
+        conn.execute(
+            "INSERT INTO matches "
+            "(match_id, league, season, date, home, away) "
+            "VALUES ('m_prob', 'EPL', '2024-2025', '2024-08-16', "
+            "'Arsenal', 'Wolves')"
+        )
+        conn.execute(
+            "INSERT INTO strategies (slug, version, config_json) "
+            "VALUES ('test', 1, '{}')"
+        )
+        sid = conn.execute(
+            "SELECT strategy_id FROM strategies WHERE slug='test'"
+        ).fetchone()[0]
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                "INSERT INTO live_predictions "
+                "(strategy_id, match_id, market, outcome, probability, "
+                " recommended_stake) "
+                "VALUES (?, 'm_prob', '1X2', 'H', 1.5, 10.0)",
+                (sid,),
+            )


### PR DESCRIPTION
## Summary

First Phase 1 deliverable: the storage foundation for the research platform. Empty package skeleton + the SQLite schema every later component will read from and write to.

### Package name: \`bsrp/\` (not \`platform/\`)

\`platform\` is a Python stdlib module name. Using it as a package directory would shadow it and silently break anything that does \`import platform\`. Renamed to \`bsrp\` (Betting Strategy Research Platform) in this PR — cheap now, much more expensive once ingest/features/strategies/etc. start importing each other.

### Schema (\`bsrp/db/migrations/001_initial_schema.sql\`)

- **matches** — league-agnostic match facts. \`match_id\` will be a deterministic hash so re-ingest is idempotent; UNIQUE on \`(league, season, date, home, away)\` belt-and-braces.
- **odds_snapshots** — multi-book, multi-market, time-series capable. Lets us track line movement and add a new book/market without touching match data.
- **features** — sparse \`(match_id, feature_name, value)\`. Each feature module owns its namespace.
- **strategies** — versioned \`(slug, version, config_json, status)\`. \`config_json\` carries feature set + model URI + sizing rule + target market.
- **backtest_runs**, **live_predictions** (Kelly-sized stakes), **settled_bets** — keyed by strategy throughout.
- CHECK constraints on probabilities (\`[0,1]\`), decimal odds (\`> 1.0\`), result (\`H/D/A\`), strategy status (\`draft/active/retired\`).

### Migration system

Deliberately minimal — no Alembic. Forward-only \`NNN_name.sql\` files in \`bsrp/db/migrations/\` applied in filename order, tracked in a \`schema_migrations\` table. \`bsrp/db/migrate.py\` is ~50 lines.

### CLI

\`\`\`
python -m bsrp init-db          # create or upgrade bsrp.db (idempotent)
\`\`\`

### Tests

8 new tests in \`tests/test_bsrp_db.py\`: migration discovery, idempotent runs, all expected tables present, FK enforcement, UNIQUE/PK enforcement on natural keys, CHECK constraint on probability range. Full suite: **52 passed** (44 legacy + 8 new).

### Not in scope (follow-up PRs)

Each gets its own focused PR; they all read from the schema landed here:

1. \`feat/bsrp-ingest-matches\` — football-data.co.uk → \`matches\`.
2. \`feat/bsrp-ingest-odds\` — API-Football → \`odds_snapshots\`.
3. \`feat/bsrp-feature-modules\` — PPG + implied_prob + odds_ratio → \`features\`.
4. \`feat/bsrp-backtest-harness\` — walk-forward + leakage guard + transaction costs + Kelly sizing.

## Test plan
- [x] \`pytest tests/ -q\` → 52 passed.
- [x] \`python -m bsrp init-db\` creates \`bsrp.db\` with all 8 tables (including \`schema_migrations\`).
- [x] Running \`python -m bsrp init-db\` a second time prints \"Already up to date.\" and doesn't re-apply migrations.
- [x] Read \`CLAUDE.md\` and confirm the Target architecture block + new Phase 1 command are documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)